### PR TITLE
Add CMake build support

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,41 @@
+name: CMake Build
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            name: Linux GCC
+          - os: windows-latest
+            name: Windows MSVC
+          - os: macos-latest
+            name: macOS Clang
+
+    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.name }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Configure CMake
+      run: cmake -B build -DCMAKE_BUILD_TYPE=Release
+
+    - name: Build
+      run: cmake --build build --config Release
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: NNets-${{ matrix.os }}
+        path: |
+          build/bin/Release/NNets*
+          build/bin/NNets*
+        if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,16 @@ packages
 .vs
 *.vcxproj.user
 
+# CMake
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+Makefile
+*.cmake
+!CMakeLists.txt
+NNets
+NNets.exe
+
 # Windows image file caches
 Thumbs.db
 ehthumbs.db

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/netkeep80/NNets/issues/3
-Your prepared branch: issue-3-5bceb1759903
-Your prepared working directory: /tmp/gh-issue-solver-1769517796499
-Your forked repository: konard/netkeep80-NNets
-Original repository (upstream): netkeep80/NNets
-
-Proceed.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,62 @@
+cmake_minimum_required(VERSION 3.14)
+project(NNets VERSION 1.0.0 LANGUAGES CXX)
+
+# Set C++ standard
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Define the executable
+add_executable(NNets main.cpp)
+
+# Platform-specific settings
+if(MSVC)
+    # MSVC-specific settings (matching Visual Studio project)
+    target_compile_definitions(NNets PRIVATE
+        WIN32
+        _CONSOLE
+        $<$<CONFIG:Debug>:_DEBUG>
+        $<$<CONFIG:Release>:NDEBUG>
+    )
+
+    target_compile_options(NNets PRIVATE
+        /W3                    # Warning level 3
+        $<$<CONFIG:Debug>:/Od>      # Disable optimization for Debug
+        $<$<CONFIG:Debug>:/RTC1>    # Runtime checks
+        $<$<CONFIG:Release>:/O2>    # Optimize for speed
+        $<$<CONFIG:Release>:/Oi>    # Enable intrinsic functions
+        $<$<CONFIG:Release>:/Oy>    # Enable frame pointer omission
+    )
+
+    # Set runtime library
+    set_property(TARGET NNets PROPERTY
+        MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+else()
+    # GCC/Clang settings
+    # Define MSVC-specific macros for cross-platform compatibility
+    target_compile_definitions(NNets PRIVATE
+        __fastcall=           # Remove __fastcall calling convention
+        strcpy_s=strcpy       # Use standard strcpy instead of MSVC's strcpy_s
+    )
+
+    target_compile_options(NNets PRIVATE
+        -Wall
+        -Wextra
+        -Wno-write-strings    # Suppress string literal to char* conversion warnings
+        -Wno-deprecated       # Suppress deprecated header warnings (strstream)
+        -fpermissive          # Allow some non-standard code constructs
+        $<$<CONFIG:Debug>:-g>
+        $<$<CONFIG:Debug>:-O0>
+        $<$<CONFIG:Release>:-O3>
+    )
+endif()
+
+# Set output directories
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_BINARY_DIR}/bin/Debug)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR}/bin/Release)
+
+# Installation rules
+install(TARGETS NNets
+    RUNTIME DESTINATION bin
+)

--- a/README.md
+++ b/README.md
@@ -18,22 +18,36 @@ This repository contains a C++ implementation of a self-structuring neural netwo
 
 • Extensible Design: The code is structured to allow users to customize the neuron operations, learning algorithms, and data representations.
 
+## Build
+
+### Using CMake (Recommended)
+
+CMake provides cross-platform build support for Linux, macOS, and Windows.
+
+```bash
+# Configure the build
+cmake -B build -DCMAKE_BUILD_TYPE=Release
+
+# Build the project
+cmake --build build --config Release
+```
+
+The executable will be located in the `build` directory.
+
+### Using Visual Studio (Windows)
+
+Open `main.sln` in Visual Studio and build the solution.
+
+### Using g++ directly
+
+```bash
+g++ -o NNets main.cpp
+```
+
 ## Usage
 
-1. Setup:
-
-• Clone the repository.
-• Make sure you have a C++ compiler installed (e.g., g++).
-
-2. Compile:
-
-• Navigate to the project directory.
-• Compile the code using a command like: g++ -o NNets main.cpp
-
-3. Run:
-
-• Execute the compiled binary: ./NNets
-• The program will prompt you to enter words.
+1. Run the compiled binary: `./NNets` (Linux/macOS) or `NNets.exe` (Windows)
+2. The program will prompt you to enter words.
 
 4. Training:
 

--- a/main.cpp
+++ b/main.cpp
@@ -788,7 +788,7 @@ float	sum(const float* ar, const int size)
 	return res;
 }
 
-void	main()
+int	main()
 {
 	cout << rand() << endl;
 
@@ -905,7 +905,7 @@ void	main()
 		strcpy_s(word, InputStr);
 		memset(InputStr, 0, StringSize);
 
-		if (cmp("Q") || cmp("q"))	return;
+		if (cmp("Q") || cmp("q"))	return 0;
 
 		for (int d = 0; d < Receptors; d++)
 		{


### PR DESCRIPTION
## Summary

- Added CMakeLists.txt with cross-platform support for MSVC, GCC, and Clang compilers
- Added GitHub Actions CI workflow for automatic builds on Linux, Windows, and macOS
- Fixed minor cross-platform compatibility issues in main.cpp (`void main()` -> `int main()`)
- Updated README.md with CMake build instructions
- Updated .gitignore for CMake build artifacts

## Changes

### CMakeLists.txt
- Minimum CMake version 3.14
- Proper compiler-specific settings for MSVC and GCC/Clang
- Cross-platform compatibility macros for Windows-specific code (`__fastcall`, `strcpy_s`)

### GitHub Actions (.github/workflows/cmake.yml)
- Builds on ubuntu-latest, windows-latest, and macos-latest
- Uploads build artifacts for each platform

### Source code fixes
- Changed `void main()` to `int main()` for standard compliance
- Changed `return;` to `return 0;` in main function

## Build Instructions

```bash
# Configure
cmake -B build -DCMAKE_BUILD_TYPE=Release

# Build
cmake --build build --config Release
```

## Test Plan

- [x] Local Linux build with GCC
- [ ] CI build verification on all platforms

Fixes #3

---
*This PR was created with [Claude Code](https://claude.com/claude-code)*